### PR TITLE
URL Cleanup

### DIFF
--- a/eureka-brixton-tester/src/main/java/com/example/EurekaBrixtonClientTesterApplication.java
+++ b/eureka-brixton-tester/src/main/java/com/example/EurekaBrixtonClientTesterApplication.java
@@ -26,7 +26,7 @@ public class EurekaBrixtonClientTesterApplication {
 
 	@RequestMapping("/check")
 	public String getHealthOfClient() {
-		return restTemplate.getForObject("http://client/health", String.class);
+		return restTemplate.getForObject("https://client/health", String.class);
 	}
 
 	public static void main(String[] args) {

--- a/eureka-camden-tester/src/main/java/com/example/EurekaBrixtonClientTesterApplication.java
+++ b/eureka-camden-tester/src/main/java/com/example/EurekaBrixtonClientTesterApplication.java
@@ -25,7 +25,7 @@ public class EurekaBrixtonClientTesterApplication {
 
 	@RequestMapping("/check")
 	public String getHealthOfClient() {
-		return restTemplate.getForObject("http://client/health", String.class);
+		return restTemplate.getForObject("https://client/health", String.class);
 	}
 
 	public static void main(String[] args) {

--- a/eureka-dalston-tester/src/main/java/com/example/EurekaBrixtonClientTesterApplication.java
+++ b/eureka-dalston-tester/src/main/java/com/example/EurekaBrixtonClientTesterApplication.java
@@ -25,7 +25,7 @@ public class EurekaBrixtonClientTesterApplication {
 
 	@RequestMapping("/check")
 	public String getHealthOfClient() {
-		return restTemplate.getForObject("http://client/health", String.class);
+		return restTemplate.getForObject("https://client/health", String.class);
 	}
 
 	public static void main(String[] args) {

--- a/eureka-edgware-tester/src/main/java/com/example/EurekaClientTesterApplication.java
+++ b/eureka-edgware-tester/src/main/java/com/example/EurekaClientTesterApplication.java
@@ -26,7 +26,7 @@ public class EurekaClientTesterApplication {
 
 	@GetMapping("/check")
 	public String foo() {
-		return restTemplate.getForObject("http://client/foo", String.class);
+		return restTemplate.getForObject("https://client/foo", String.class);
 	}
 
 	public static void main(String[] args) {

--- a/eureka-finchley-tester/src/main/java/com/example/EurekaClientTesterApplication.java
+++ b/eureka-finchley-tester/src/main/java/com/example/EurekaClientTesterApplication.java
@@ -26,7 +26,7 @@ public class EurekaClientTesterApplication {
 
 	@GetMapping("/check")
 	public String foo() {
-		return restTemplate.getForObject("http://client/foo", String.class);
+		return restTemplate.getForObject("https://client/foo", String.class);
 	}
 
 	public static void main(String[] args) {

--- a/eureka-greenwich-tester/src/main/java/com/example/EurekaClientTesterApplication.java
+++ b/eureka-greenwich-tester/src/main/java/com/example/EurekaClientTesterApplication.java
@@ -26,7 +26,7 @@ public class EurekaClientTesterApplication {
 
 	@GetMapping("/check")
 	public String foo() {
-		return restTemplate.getForObject("http://client/foo", String.class);
+		return restTemplate.getForObject("https://client/foo", String.class);
 	}
 
 	public static void main(String[] args) {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://client/foo (UnknownHostException) with 3 occurrences migrated to:  
  https://client/foo ([https](https://client/foo) result UnknownHostException).
* [ ] http://client/health (UnknownHostException) with 3 occurrences migrated to:  
  https://client/health ([https](https://client/health) result UnknownHostException).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8761/eureka/ with 12 occurrences